### PR TITLE
Update benchmarks.slurm

### DIFF
--- a/benchmarks.slurm
+++ b/benchmarks.slurm
@@ -14,7 +14,7 @@
 #SBATCH --mem=0
 # make all cores use the same clock speed so it looks more like a BSP computer
 #SBATCH --cpu-freq=medium
-#SBATCH --account=education-eemcs-courses-paf24
+#SBATCH --account=education-eemcs-courses-mastermath
 
 # the driver writes matlab/octave executable output,
 # we pipe all of it into an m-file for post-processing
@@ -25,7 +25,7 @@ echo "" > bench_data.m
 NUMA_DOMAINS="0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1,1,2,2,2,2,2,2,2,2,2,2,2,2,3,3,3,3,3,3,3,3,3,3,3,3"
 
 # load necessary modules for running Fortran coarray code
-module load 2024rc1 openmpi opencoarrays
+module load 2024r1 openmpi opencoarrays
 for np in 12 24 48; do
     srun  -n $np --cpu-bind=map_ldom:${NUMA_DOMAINS} ./main_benchmarks.x |& grep -v UCX >> bench_data.m
 done


### PR DESCRIPTION
Fixed typo in the "2024r1" module and changed the --account line to the one from sorting.slurm as the original account did not work for me. (Not sure if this is also the case for others, but this worked for me.)